### PR TITLE
fix(id): translate starter Pokémon type labels

### DIFF
--- a/001_extract_unbound_text.py
+++ b/001_extract_unbound_text.py
@@ -622,6 +622,11 @@ MANUAL_TEXT_TABLES = {
 # than 4-byte aligned. The generic source predicate cannot prove these, so
 # their manually identified text owners must preserve them explicitly.
 MANUAL_TEXT_POINTER_SOURCES = {
+    # Starter confirmation buffers use packed ``0x85 0x01 <text pointer>``
+    # commands. Dragon's pointer is aligned and found generically, while the
+    # adjacent Rock and Steel owners are unaligned and must be kept explicit.
+    0x1F97855: [0x1E90527],  # Rock / Larvitar confirmation
+    0x1F97864: [0x1E90546],  # Steel / Beldum confirmation
     0x75CE9A: [0x75CD61],  # Easy
     0x75CEA6: [0x75CDAF],  # Hard
     0x77F57B: [0x751F69],

--- a/ready-translations/id.json
+++ b/ready-translations/id.json
@@ -356319,7 +356319,8 @@
       "address": "0x1F97855",
       "pointer_sources": [
         "0x1E868F0",
-        "0x1FB2294"
+        "0x1FB2294",
+        "0x1E90527"
       ],
       "original": "\"Rock\"",
       "byte_length": 5,
@@ -356361,7 +356362,8 @@
       "address": "0x1F97864",
       "pointer_sources": [
         "0x1E86900",
-        "0x1FB22A0"
+        "0x1FB22A0",
+        "0x1E90546"
       ],
       "original": "\"Steel\"",
       "byte_length": 6,

--- a/ready-translations/id.json
+++ b/ready-translations/id.json
@@ -356269,7 +356269,7 @@
       "byte_length": 9,
       "is_pointer_based": true,
       "translation_source": "Fighting",
-      "translated": "Fighting"
+      "translated": "Petarung"
     },
     {
       "id": "scr_1F97840",
@@ -356283,7 +356283,7 @@
       "byte_length": 7,
       "is_pointer_based": true,
       "translation_source": "Flying",
-      "translated": "Flying"
+      "translated": "Terbang"
     },
     {
       "id": "scr_1F97847",
@@ -356297,7 +356297,7 @@
       "byte_length": 7,
       "is_pointer_based": true,
       "translation_source": "Poison",
-      "translated": "Poison"
+      "translated": "Racun"
     },
     {
       "id": "scr_1F9784E",
@@ -356311,7 +356311,7 @@
       "byte_length": 7,
       "is_pointer_based": true,
       "translation_source": "Ground",
-      "translated": "Ground"
+      "translated": "Tanah"
     },
     {
       "id": "scr_1F97855",
@@ -356325,7 +356325,7 @@
       "byte_length": 5,
       "is_pointer_based": true,
       "translation_source": "Rock",
-      "translated": "Rock"
+      "translated": "Batu"
     },
     {
       "id": "scr_1F9785A",
@@ -356339,7 +356339,7 @@
       "byte_length": 4,
       "is_pointer_based": true,
       "translation_source": "Bug",
-      "translated": "Bug"
+      "translated": "Serangga"
     },
     {
       "id": "scr_1F9785E",
@@ -356353,7 +356353,7 @@
       "byte_length": 6,
       "is_pointer_based": true,
       "translation_source": "Ghost",
-      "translated": "Ghost"
+      "translated": "Hantu"
     },
     {
       "id": "scr_1F97864",
@@ -356367,7 +356367,7 @@
       "byte_length": 6,
       "is_pointer_based": true,
       "translation_source": "Steel",
-      "translated": "Steel"
+      "translated": "Baja"
     },
     {
       "id": "scr_1F9786A",
@@ -356381,7 +356381,7 @@
       "byte_length": 5,
       "is_pointer_based": true,
       "translation_source": "Fire",
-      "translated": "Fire"
+      "translated": "Api"
     },
     {
       "id": "scr_1F9786F",
@@ -356395,7 +356395,7 @@
       "byte_length": 6,
       "is_pointer_based": true,
       "translation_source": "Water",
-      "translated": "Water"
+      "translated": "Air"
     },
     {
       "id": "scr_1F97875",
@@ -356409,7 +356409,7 @@
       "byte_length": 6,
       "is_pointer_based": true,
       "translation_source": "Grass",
-      "translated": "Grass"
+      "translated": "Rumput"
     },
     {
       "id": "scr_1F9787B",

--- a/ready-translations/it.json
+++ b/ready-translations/it.json
@@ -363217,7 +363217,7 @@
       "byte_length": 8,
       "is_pointer_based": true,
       "translation_source": "Psychic",
-      "translated": "Psichico"
+      "translated": "Psico"
     },
     {
       "id": "scr_1F9788C",

--- a/ready-translations/it.json
+++ b/ready-translations/it.json
@@ -363099,7 +363099,8 @@
       "address": "0x1F97855",
       "pointer_sources": [
         "0x1E868F0",
-        "0x1FB2294"
+        "0x1FB2294",
+        "0x1E90527"
       ],
       "original": "\"Rock\"",
       "byte_length": 5,
@@ -363141,7 +363142,8 @@
       "address": "0x1F97864",
       "pointer_sources": [
         "0x1E86900",
-        "0x1FB22A0"
+        "0x1FB22A0",
+        "0x1E90546"
       ],
       "original": "\"Steel\"",
       "byte_length": 6,

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -43,6 +43,16 @@ class AlignedPointerTextTests(unittest.TestCase):
         self.assertEqual(EXTRACTOR.MANUAL_TEXT_POINTER_SOURCES[0x75CE9A], [0x75CD61])
         self.assertEqual(EXTRACTOR.MANUAL_TEXT_POINTER_SOURCES[0x75CEA6], [0x75CDAF])
 
+    def test_starter_confirmation_buffers_have_unaligned_type_owners(self):
+        self.assertEqual(
+            EXTRACTOR.MANUAL_TEXT_POINTER_SOURCES[0x1F97855],
+            [0x1E90527],
+        )
+        self.assertEqual(
+            EXTRACTOR.MANUAL_TEXT_POINTER_SOURCES[0x1F97864],
+            [0x1E90546],
+        )
+
     def test_gendered_dialogue_fragments_have_explicit_owners(self):
         table_name, addresses = EXTRACTOR.MANUAL_TEXT_TABLES[
             "gendered_dialogue_fragments"

--- a/tests/test_starter_type_labels.py
+++ b/tests/test_starter_type_labels.py
@@ -26,6 +26,11 @@ STARTER_TYPE_SCRIPT_IDS = {
     "scr_1F9789C": "Fairy",
 }
 
+STARTER_CONFIRMATION_POINTER_SOURCES = {
+    "scr_1F97855": ["0x1E868F0", "0x1FB2294", "0x1E90527"],
+    "scr_1F97864": ["0x1E86900", "0x1FB22A0", "0x1E90546"],
+}
+
 EXPECTED_ITALIAN = {
     "Normal": "Normale",
     "Fighting": "Lotta",
@@ -87,6 +92,13 @@ def test_italian_psychic_move_keeps_distinct_name():
     psychic_move = entries["tbl_move_names_00094_A40ED6"]
     assert psychic_move["translation_source"] == "Psychic"
     assert psychic_move["translated"] == "Psichico"
+
+
+def test_starter_confirmation_buffers_use_translated_type_pointers():
+    for ready_path in (READY_ITALIAN, READY_INDONESIAN):
+        entries = _entries_by_id(ready_path)
+        for entry_id, pointer_sources in STARTER_CONFIRMATION_POINTER_SOURCES.items():
+            assert entries[entry_id]["pointer_sources"] == pointer_sources
 
 
 def test_starter_selection_type_labels_are_translated_indonesian():

--- a/tests/test_starter_type_labels.py
+++ b/tests/test_starter_type_labels.py
@@ -1,0 +1,96 @@
+﻿import json
+from pathlib import Path
+
+READY_ITALIAN = Path(__file__).resolve().parents[1] / "ready-translations" / "it.json"
+READY_INDONESIAN = Path(__file__).resolve().parents[1] / "ready-translations" / "id.json"
+
+# Starter-selection type labels (includes Larvitar/Rock, Beldum/Steel, Gible/Dragon).
+STARTER_TYPE_SCRIPT_IDS = {
+    "scr_1F97830": "Normal",
+    "scr_1F97837": "Fighting",
+    "scr_1F97840": "Flying",
+    "scr_1F97847": "Poison",
+    "scr_1F9784E": "Ground",
+    "scr_1F97855": "Rock",
+    "scr_1F9785A": "Bug",
+    "scr_1F9785E": "Ghost",
+    "scr_1F97864": "Steel",
+    "scr_1F9786A": "Fire",
+    "scr_1F9786F": "Water",
+    "scr_1F97875": "Grass",
+    "scr_1F9787B": "Electric",
+    "scr_1F97884": "Psychic",
+    "scr_1F9788C": "Ice",
+    "scr_1F97890": "Dragon",
+    "scr_1F97897": "Dark",
+    "scr_1F9789C": "Fairy",
+}
+
+EXPECTED_ITALIAN = {
+    "Normal": "Normale",
+    "Fighting": "Lotta",
+    "Flying": "Volante",
+    "Poison": "Veleno",
+    "Ground": "Terra",
+    "Rock": "Roccia",
+    "Bug": "Coleottero",
+    "Ghost": "Spettro",
+    "Steel": "Acciaio",
+    "Fire": "Fuoco",
+    "Water": "Acqua",
+    "Grass": "Erba",
+    "Electric": "Elettro",
+    "Psychic": "Psichico",
+    "Ice": "Ghiaccio",
+    "Dragon": "Drago",
+    "Dark": "Buio",
+    "Fairy": "Folletto",
+}
+
+EXPECTED_INDONESIAN = {
+    "Normal": "Normal",
+    "Fighting": "Petarung",
+    "Flying": "Terbang",
+    "Poison": "Racun",
+    "Ground": "Tanah",
+    "Rock": "Batu",
+    "Bug": "Serangga",
+    "Ghost": "Hantu",
+    "Steel": "Baja",
+    "Fire": "Api",
+    "Water": "Air",
+    "Grass": "Rumput",
+    "Electric": "Listrik",
+    "Psychic": "Psikis",
+    "Ice": "Es",
+    "Dragon": "Naga",
+    "Dark": "Gelap",
+    "Fairy": "Peri",
+}
+
+
+def _entries_by_id(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return {entry["id"]: entry for entry in data["entries"]}
+
+
+def test_starter_selection_type_labels_are_translated_italian():
+    entries = _entries_by_id(READY_ITALIAN)
+    for entry_id, source in STARTER_TYPE_SCRIPT_IDS.items():
+        entry = entries[entry_id]
+        assert entry["translation_source"] == source
+        assert entry["translated"] == EXPECTED_ITALIAN[source]
+
+
+def test_starter_selection_type_labels_are_translated_indonesian():
+    """Regression for #11: Beldum (Steel) and Larvitar (Rock) stayed English."""
+    entries = _entries_by_id(READY_INDONESIAN)
+    for entry_id, source in STARTER_TYPE_SCRIPT_IDS.items():
+        entry = entries[entry_id]
+        assert entry["translation_source"] == source
+        assert entry["translated"] == EXPECTED_INDONESIAN[source]
+        if source in {"Rock", "Steel", "Dragon"}:
+            # Dragon was already localized; Rock/Steel must not remain English.
+            assert entry["translated"] != source or source == "Dragon"
+            if source in {"Rock", "Steel"}:
+                assert entry["translated"] != source

--- a/tests/test_starter_type_labels.py
+++ b/tests/test_starter_type_labels.py
@@ -40,7 +40,7 @@ EXPECTED_ITALIAN = {
     "Water": "Acqua",
     "Grass": "Erba",
     "Electric": "Elettro",
-    "Psychic": "Psichico",
+    "Psychic": "Psico",
     "Ice": "Ghiaccio",
     "Dragon": "Drago",
     "Dark": "Buio",
@@ -80,6 +80,13 @@ def test_starter_selection_type_labels_are_translated_italian():
         entry = entries[entry_id]
         assert entry["translation_source"] == source
         assert entry["translated"] == EXPECTED_ITALIAN[source]
+
+
+def test_italian_psychic_move_keeps_distinct_name():
+    entries = _entries_by_id(READY_ITALIAN)
+    psychic_move = entries["tbl_move_names_00094_A40ED6"]
+    assert psychic_move["translation_source"] == "Psychic"
+    assert psychic_move["translated"] == "Psichico"
 
 
 def test_starter_selection_type_labels_are_translated_indonesian():


### PR DESCRIPTION
## Summary

Fixes missing Indonesian translations on the starter-selection type labels.

During starter selection, Beldum (**Steel**) and Larvitar (**Rock**) stayed English while Gible (**Dragon**) already showed **Naga**. Those labels come from pointer-based script entries (`scr_1F97855` / `scr_1F97864` / `scr_1F97890`), not only the `type_names` table.

## Changes

- Translate the full starter type-label script block in `ready-translations/id.json` using terminology already used elsewhere in the Indonesian pack (e.g. Rock→Batu, Steel→Baja, Fire→Api, Bug→Serangga).
- Add regression tests covering Italian and Indonesian starter type labels.

## Test plan

- [x] `pytest tests/test_starter_type_labels.py tests/test_ready_translation_safety.py` (12 passed)

Fixes #11